### PR TITLE
fix: remove rec body parameter

### DIFF
--- a/packages/signify-ts/src/keri/app/credentialing.ts
+++ b/packages/signify-ts/src/keri/app/credentialing.ts
@@ -776,16 +776,10 @@ export class Ipex {
             );
     }
 
-    async submitApply(
-        name: string,
-        exn: Serder,
-        sigs: string[],
-        recp: string[]
-    ): Promise<any> {
+    async submitApply(name: string, exn: Serder, sigs: string[]): Promise<any> {
         const body = {
             exn: exn.sad,
             sigs,
-            rec: recp,
         };
 
         const response = await this.client.fetch(
@@ -823,14 +817,12 @@ export class Ipex {
         name: string,
         exn: Serder,
         sigs: string[],
-        atc: string,
-        recp: string[]
+        atc: string
     ): Promise<any> {
         const body = {
             exn: exn.sad,
             sigs,
             atc,
-            rec: recp,
         };
 
         const response = await this.client.fetch(
@@ -864,16 +856,10 @@ export class Ipex {
             );
     }
 
-    async submitAgree(
-        name: string,
-        exn: Serder,
-        sigs: string[],
-        recp: string[]
-    ): Promise<any> {
+    async submitAgree(name: string, exn: Serder, sigs: string[]): Promise<any> {
         const body = {
             exn: exn.sad,
             sigs,
-            rec: recp,
         };
 
         const response = await this.client.fetch(
@@ -935,14 +921,12 @@ export class Ipex {
         name: string,
         exn: Serder,
         sigs: string[],
-        atc: string,
-        recp: string[]
+        atc: string
     ): Promise<any> {
         const body = {
             exn: exn.sad,
             sigs: sigs,
             atc: atc,
-            rec: recp,
         };
 
         const response = await this.client.fetch(
@@ -980,14 +964,12 @@ export class Ipex {
         name: string,
         exn: Serder,
         sigs: string[],
-        atc: string,
-        recp: string[]
+        atc: string
     ): Promise<any> {
         const body = {
             exn: exn.sad,
             sigs: sigs,
             atc: atc,
-            rec: recp,
         };
 
         const response = await this.client.fetch(

--- a/packages/signify-ts/test-integration/credentials.test.ts
+++ b/packages/signify-ts/test-integration/credentials.test.ts
@@ -249,7 +249,7 @@ test('issuer IPEX grant', async () => {
 
     const op = await issuerClient
         .ipex()
-        .submitGrant(issuerAid.name, grant, gsigs, gend, [holderAid.prefix]);
+        .submitGrant(issuerAid.name, grant, gsigs, gend);
     await waitOperation(issuerClient, op);
 });
 
@@ -278,7 +278,7 @@ test('holder IPEX admit', async () => {
     });
     const op = await holderClient
         .ipex()
-        .submitAdmit(holderAid.name, admit, sigs, aend, [issuerAid.prefix]);
+        .submitAdmit(holderAid.name, admit, sigs, aend);
     await waitOperation(holderClient, op);
 
     await markAndRemoveNotification(holderClient, grantNotification);
@@ -315,7 +315,7 @@ test('verifier IPEX apply', async () => {
 
     const op = await verifierClient
         .ipex()
-        .submitApply(verifierAid.name, apply, sigs, [holderAid.prefix]);
+        .submitApply(verifierAid.name, apply, sigs);
     await waitOperation(verifierClient, op);
 });
 
@@ -351,7 +351,7 @@ test('holder IPEX apply receive and offer', async () => {
 
     const op = await holderClient
         .ipex()
-        .submitOffer(holderAid.name, offer, sigs, end, [verifierAid.prefix]);
+        .submitOffer(holderAid.name, offer, sigs, end);
     await waitOperation(holderClient, op);
 });
 
@@ -381,7 +381,7 @@ test('verifier receive offer and agree', async () => {
 
     const op = await verifierClient
         .ipex()
-        .submitAgree(verifierAid.name, agree, sigs, [holderAid.prefix]);
+        .submitAgree(verifierAid.name, agree, sigs);
     await waitOperation(verifierClient, op);
 });
 
@@ -420,9 +420,7 @@ test('holder IPEX receive agree and grant/present', async () => {
 
     const op = await holderClient
         .ipex()
-        .submitGrant(holderAid.name, grant2, gsigs2, gend2, [
-            verifierAid.prefix,
-        ]);
+        .submitGrant(holderAid.name, grant2, gsigs2, gend2);
     await waitOperation(holderClient, op);
 });
 
@@ -448,9 +446,7 @@ test('verifier receives IPEX grant', async () => {
 
     const op = await verifierClient
         .ipex()
-        .submitAdmit(verifierAid.name, admit3, sigs3, aend3, [
-            holderAid.prefix,
-        ]);
+        .submitAdmit(verifierAid.name, admit3, sigs3, aend3);
     await waitOperation(verifierClient, op);
 
     await markAndRemoveNotification(verifierClient, verifierGrantNote);
@@ -536,9 +532,7 @@ test('LE credential IPEX grant', async () => {
 
     const op = await holderClient
         .ipex()
-        .submitGrant(holderAid.name, grant, gsigs, gend, [
-            legalEntityAid.prefix,
-        ]);
+        .submitGrant(holderAid.name, grant, gsigs, gend);
     await waitOperation(holderClient, op);
 });
 
@@ -559,9 +553,7 @@ test('Legal Entity IPEX admit', async () => {
 
     const op = await legalEntityClient
         .ipex()
-        .submitAdmit(legalEntityAid.name, admit, sigs, aend, [
-            holderAid.prefix,
-        ]);
+        .submitAdmit(legalEntityAid.name, admit, sigs, aend);
     await waitOperation(legalEntityClient, op);
 
     await markAndRemoveNotification(legalEntityClient, grantNotification);

--- a/packages/signify-ts/test-integration/multisig-holder.test.ts
+++ b/packages/signify-ts/test-integration/multisig-holder.test.ts
@@ -290,9 +290,7 @@ async function issueCredential(
             iss: result.iss,
         });
 
-        const op = await client
-            .ipex()
-            .submitGrant(name, grant, gsigs, end, [data.a.i]);
+        const op = await client.ipex().submitGrant(name, grant, gsigs, end);
         await waitOperation(client, op);
     }
 
@@ -322,9 +320,7 @@ async function multisigAdmitCredential(
         datetime: TIME,
     });
 
-    const op = await client
-        .ipex()
-        .submitAdmit(groupName, admit, sigs, end, [issuerPrefix]);
+    const op = await client.ipex().submitAdmit(groupName, admit, sigs, end);
 
     const mstate = gHab['state'];
     const seal = [

--- a/packages/signify-ts/test-integration/multisig-vlei-issuance.test.ts
+++ b/packages/signify-ts/test-integration/multisig-vlei-issuance.test.ts
@@ -154,6 +154,16 @@ test('multisig-vlei-issuance', async function run() {
         clientECR.oobis().get('ECR', 'agent'),
     ]);
 
+    assert.equal(oobiGAR1.oobis.length, 1);
+    assert.equal(oobiGAR2.oobis.length, 1);
+    assert.equal(oobiQAR1.oobis.length, 1);
+    assert.equal(oobiQAR2.oobis.length, 1);
+    assert.equal(oobiQAR3.oobis.length, 1);
+    assert.equal(oobiLAR1.oobis.length, 1);
+    assert.equal(oobiLAR2.oobis.length, 1);
+    assert.equal(oobiLAR3.oobis.length, 1);
+    assert.equal(oobiECR.oobis.length, 1);
+
     await Promise.all([
         getOrCreateContact(clientGAR1, 'GAR2', oobiGAR2.oobis[0]),
         getOrCreateContact(clientGAR2, 'GAR1', oobiGAR1.oobis[0]),

--- a/packages/signify-ts/test-integration/multisig.test.ts
+++ b/packages/signify-ts/test-integration/multisig.test.ts
@@ -740,7 +740,7 @@ test('Grant credential', async () => {
 
     const op1 = await client1
         .ipex()
-        .submitGrant('multisig', grant1, gsigs1, gend1, [aid4.prefix]);
+        .submitGrant('multisig', grant1, gsigs1, gend1);
 
     const ghab1 = await client1.identifiers().get('multisig');
     const gstate1 = ghab1['state'];
@@ -784,7 +784,7 @@ test('Grant credential', async () => {
 
     const op2 = await client2
         .ipex()
-        .submitGrant('multisig', grant2, gsigs2, gend2, [aid4.prefix]);
+        .submitGrant('multisig', grant2, gsigs2, gend2);
 
     const ghab2 = await client2.identifiers().get('multisig');
     const gstate2 = ghab2['state'];
@@ -828,7 +828,7 @@ test('Grant credential', async () => {
 
     const op3 = await client3
         .ipex()
-        .submitGrant('multisig', grant3, gsigs3, gend3, [aid4.prefix]);
+        .submitGrant('multisig', grant3, gsigs3, gend3);
 
     const ghab3 = await client3.identifiers().get('multisig');
     const gstate3 = ghab3['state'];
@@ -882,9 +882,7 @@ test('Admit credential', async () => {
         recipient: res.exn.i,
     });
 
-    const op4 = await client4
-        .ipex()
-        .submitAdmit('holder', admit, asigs, aend, [res.exn.i]);
+    const op4 = await client4.ipex().submitAdmit('holder', admit, asigs, aend);
 
     await waitOperation(client4, op4);
 

--- a/packages/signify-ts/test-integration/singlesig-vlei-issuance.test.ts
+++ b/packages/signify-ts/test-integration/singlesig-vlei-issuance.test.ts
@@ -514,7 +514,7 @@ async function sendGrantMessage(
 
     let op = await senderClient
         .ipex()
-        .submitGrant(senderAid.name, grant, gsigs, gend, [recipientAid.prefix]);
+        .submitGrant(senderAid.name, grant, gsigs, gend);
     op = await waitOperation(senderClient, op);
 }
 
@@ -540,7 +540,7 @@ async function sendAdmitMessage(
 
     let op = await senderClient
         .ipex()
-        .submitAdmit(senderAid.name, admit, sigs, aend, [recipientAid.prefix]);
+        .submitAdmit(senderAid.name, admit, sigs, aend);
     op = await waitOperation(senderClient, op);
 
     await markAndRemoveNotification(senderClient, grantNotification);

--- a/packages/signify-ts/test-integration/utils/multisig-utils.ts
+++ b/packages/signify-ts/test-integration/utils/multisig-utils.ts
@@ -171,9 +171,7 @@ export async function admitMultisig(
         datetime: timestamp,
     });
 
-    await client
-        .ipex()
-        .submitAdmit(multisigAID.name, admit, sigs, end, [recipientAID.prefix]);
+    await client.ipex().submitAdmit(multisigAID.name, admit, sigs, end);
 
     const mstate = multisigAID.state;
     const seal = [
@@ -343,9 +341,7 @@ export async function grantMultisig(
         datetime: timestamp,
     });
 
-    await client
-        .ipex()
-        .submitGrant(multisigAID.name, grant, sigs, end, [recipientAID.prefix]);
+    await client.ipex().submitGrant(multisigAID.name, grant, sigs, end);
 
     const mstate = multisigAID.state;
     const seal = [

--- a/packages/signify-ts/test-integration/utils/test-util.ts
+++ b/packages/signify-ts/test-integration/utils/test-util.ts
@@ -51,9 +51,7 @@ export async function admitSinglesig(
         recipient: recipientAid.prefix,
     });
 
-    await client
-        .ipex()
-        .submitAdmit(aidName, admit, sigs, aend, [recipientAid.prefix]);
+    await client.ipex().submitAdmit(aidName, admit, sigs, aend);
 }
 
 /**

--- a/packages/signify-ts/test/app/credentialing.test.ts
+++ b/packages/signify-ts/test/app/credentialing.test.ts
@@ -261,7 +261,7 @@ describe('Ipex', () => {
         assert.deepStrictEqual(ngsigs, gsigs);
         assert.deepStrictEqual(ngend, ngend);
 
-        await ipex.submitGrant('multisig', ng, ngsigs, ngend, [holder]);
+        await ipex.submitGrant('multisig', ng, ngsigs, ngend);
         let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0],
@@ -294,7 +294,7 @@ describe('Ipex', () => {
             'AAC4MTRQR-U8_3Hf53f2nJuh3n93lauXSHUkF1Yk2diTHwF-qkcBHn_jd-6pgRnRtBV2CInfwZyOsSL2CrRyuNEN',
         ]);
 
-        await ipex.submitAdmit('multisig', admit, asigs, aend, [holder]);
+        await ipex.submitAdmit('multisig', admit, asigs, aend);
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0],
@@ -377,7 +377,7 @@ describe('Ipex', () => {
 
             assert.equal(applyEnd, '');
 
-            await ipex.submitApply('multisig', apply, applySigs, [holder]);
+            await ipex.submitApply('multisig', apply, applySigs);
             let lastCall =
                 fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
             assert.equal(
@@ -431,9 +431,7 @@ describe('Ipex', () => {
             ]);
             assert.equal(offerEnd, '');
 
-            await ipex.submitOffer('multisig', offer, offerSigs, offerEnd, [
-                holder,
-            ]);
+            await ipex.submitOffer('multisig', offer, offerSigs, offerEnd);
             lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
             assert.equal(
                 lastCall[0],
@@ -470,7 +468,7 @@ describe('Ipex', () => {
             ]);
             assert.equal(agreeEnd, '');
 
-            await ipex.submitAgree('multisig', agree, agreeSigs, [holder]);
+            await ipex.submitAgree('multisig', agree, agreeSigs);
             lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
             assert.equal(
                 lastCall[0],
@@ -565,7 +563,7 @@ describe('Ipex', () => {
             assert.deepStrictEqual(ngsigs, gsigs);
             assert.deepStrictEqual(ngend, ngend);
 
-            await ipex.submitGrant('multisig', ng, ngsigs, ngend, [holder]);
+            await ipex.submitGrant('multisig', ng, ngsigs, ngend);
             lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
             assert.equal(
                 lastCall[0],
@@ -598,7 +596,7 @@ describe('Ipex', () => {
                 'AABqIUE6czxB5BotjxFUZT9Gu8tkFkAx7bOYQzWD422r-HS8z_6gaNuIlpnABHjxlX7PEXFDTj8WnoGVW197XlQP',
             ]);
 
-            await ipex.submitAdmit('multisig', admit, asigs, aend, [holder]);
+            await ipex.submitAdmit('multisig', admit, asigs, aend);
             lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
             assert.equal(
                 lastCall[0],
@@ -667,9 +665,7 @@ describe('Ipex', () => {
         ]);
         assert.equal(offerEnd, '');
 
-        await ipex.submitOffer('multisig', offer, offerSigs, offerEnd, [
-            holder,
-        ]);
+        await ipex.submitOffer('multisig', offer, offerSigs, offerEnd);
         const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0],


### PR DESCRIPTION
Removes the "rec" body parameter from all IPEX and EXN calls as they are no longer used in KERIA