### PR TITLE
ci(gha): upgrade macos runner to macos-15

### DIFF
--- a/.github/workflows/python-app-ci.yml
+++ b/.github/workflows/python-app-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-latest]
+        os: [macos-15, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12.8
+      - name: Config libsodium
+        if: runner.os == 'macOS'
+        run: |
+          echo "SODIUM_INSTALL=system" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:


### PR DESCRIPTION
## Summary
- replace the unavailable `macos-13` runner with `macos-15`
- configure system libsodium paths for the ARM macOS runner

## Test plan
- [x] Confirmed this PR contains only upstream commit `dae95ce1aa0738f31a74814993dc72e517e56aaf`
- [x] GitHub Actions macOS job runs successfully